### PR TITLE
Updates Scala maven plugin to 3.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 
     <!-- fixed versions -->
     <tycho.version>0.18.0</tycho.version>
-    <scala.plugin.version>3.0.2</scala.plugin.version>
+    <scala.plugin.version>3.1.5</scala.plugin.version>
 
     <!-- tycho test related -->
     <tycho.test.OSspecific />


### PR DESCRIPTION
Previous version was not handling correctly 2.11.0-SNAPSHOT and
2.11.0-M5 Scala library versions.

We need to make a release, and update the plugins.
