### PR TITLE
Use luna branch instead of 4.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <profile>
       <id>scala-2.11.x</id>
       <properties>
-        <scala.version>2.11.1</scala.version>
+        <scala.version>2.11.5</scala.version>
         <version.suffix>2_11</version.suffix>
         <scala.version.short>2.11</scala.version.short>
         <ecosystem-scala-version>211</ecosystem-scala-version>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <version.suffix>2_11</version.suffix>
         <scala.version.short>2.11</scala.version.short>
         <ecosystem-scala-version>211</ecosystem-scala-version>
-        <scala-ide-branch>4.0.x</scala-ide-branch>
+        <scala-ide-branch>luna</scala-ide-branch>
       </properties>
       <repositories>
         <repository>


### PR DESCRIPTION
4.0.x uses the deprecated kepler release

---

It would be nice if someone could release the `1.0.9` version of this library, which includes this fix.