### PR TITLE
Set Scala version to 2.12.0 for building scala-ide-play2 plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
     <profile>
       <id>scala-2.12.x</id>
       <properties>
-        <scala.version>2.12.0-SNAPSHOT</scala.version>
+        <scala.version>2.12.0</scala.version>
         <version.suffix>2_12</version.suffix>
         <scala.version.short>2.12</scala.version.short>
         <ecosystem-scala-version>212</ecosystem-scala-version>


### PR DESCRIPTION
This allows me to build the scala-ide-play2 plugin for the new scala-ide version.
The build args are:  `mvn -Peclipse-neon -Pscala-ide-dev -Pscala-2.12.x clean verify`

I'm not sure if this is how you want to set the Scala version, but I'm putting this here so others can see it and build the plugin for e.g. testing against Play 2.5 and 2.6 and this bug: https://github.com/scala-ide/scala-ide-play2/issues/275